### PR TITLE
Fixed Issue #3 where failed to import due to the http library changing location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 install:
-  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.8.0
+  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.11.0
   - export PATH="$HOME/.deno/bin:$PATH"
 
 script:

--- a/dependencies.js
+++ b/dependencies.js
@@ -1,3 +1,5 @@
-export * as http from 'https://deno.land/x/http@v0.8.0/server.ts';
-export { Status as status } from 'https://deno.land/x/http@v0.8.0/http_status.ts';
-export { STATUS_TEXT as statusText } from 'https://deno.land/x/http@v0.8.0/http_status.ts';
+import * as http from "https://deno.land/std@v0.11.0/http/server.ts";
+import { Status as status } from "https://deno.land/std@v0.11.0/http/http_status.ts";
+import { STATUS_TEXT as statusText } from "https://deno.land/std@v0.11.0/http/http_status.ts";
+
+export { http, status, statusText };


### PR DESCRIPTION
I simply updated the URL of the libraries, I also reformatted the dependencies document as the latest version of deno was giving an error when you attempted to export from a location.

```
1 export * as http from 'https://deno.land/std@v0.8.0/http/server.ts';
           ~~

error TS1005: ';' expected.
```