### PR TITLE
Improve request API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ install:
   - export PATH="$HOME/.deno/bin:$PATH"
 
 script:
-  - find test -name \*.js -type f -print0 | xargs -0 -n1 deno
+  - deno test.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 
 install:
-  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.18.0
+  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.19.0
   - export PATH="$HOME/.deno/bin:$PATH"
 
 script:
-  - deno test/server.js
-  - deno test/router.js
-  - deno test/toolkit.js
+  - find test -name \*.js -type f -print0 | xargs -0 -n1 deno

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Pogo is an easy to use, safe, and expressive framework for writing web servers and applications. It is inspired by [hapi](https://github.com/hapijs/hapi).
 
-*Supports Deno v0.6.0 and higher.*
+*Supports Deno v0.19.0 and higher.*
 
 ## Contents
 

--- a/dependencies.js
+++ b/dependencies.js
@@ -1,5 +1,5 @@
-import * as http from "https://deno.land/std@v0.18.0/http/server.ts";
-import { Status as status } from "https://deno.land/std@v0.18.0/http/http_status.ts";
-import { STATUS_TEXT as statusText } from "https://deno.land/std@v0.18.0/http/http_status.ts";
+import * as http from 'https://deno.land/std@v0.19.0/http/server.ts';
+import { Status as status } from 'https://deno.land/std@v0.19.0/http/http_status.ts';
+import { STATUS_TEXT as statusText } from 'https://deno.land/std@v0.19.0/http/http_status.ts';
 
 export { http, status, statusText };

--- a/dependencies.js
+++ b/dependencies.js
@@ -1,5 +1,8 @@
 import * as http from 'https://deno.land/std@v0.19.0/http/server.ts';
-import { Status as status } from 'https://deno.land/std@v0.19.0/http/http_status.ts';
-import { STATUS_TEXT as statusText } from 'https://deno.land/std@v0.19.0/http/http_status.ts';
+import { Status as status, STATUS_TEXT as statusText } from 'https://deno.land/std@v0.19.0/http/http_status.ts';
 
-export { http, status, statusText };
+export {
+    http,
+    status,
+    statusText
+};

--- a/dev-dependencies.js
+++ b/dev-dependencies.js
@@ -1,0 +1,9 @@
+import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
+import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
+
+export {
+    assertEquals,
+    assertStrictEq,
+    runTests,
+    test
+};

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,0 +1,41 @@
+import Response from './response.js';
+
+export default class Request {
+    constructor(option) {
+        this.raw = option.raw;
+        this.route = option.route;
+        this.method = this.raw.method;
+        this.headers = this.raw.headers || new Headers({ host : 'localhost' });
+        this.params = this.route.params;
+        this.response = new Response();
+        this.server = option.server;
+        this.url = new URL(this.raw.url, 'http://' + this.headers.get('host'));
+    }
+    body(...args) {
+        return this.raw.body(...args);
+    }
+    bodyStream(...args) {
+        return this.raw.bodyStream(...args);
+    }
+    get host() {
+        return this.url.host;
+    }
+    get hostname() {
+        return this.url.hostname;
+    }
+    get href() {
+        return this.url.href;
+    }
+    get origin() {
+        return this.url.origin;
+    }
+    get path() {
+        return this.url.pathname;
+    }
+    get search() {
+        return this.url.search;
+    }
+    get searchParams() {
+        return this.url.searchParams;
+    }
+}

--- a/lib/respond.js
+++ b/lib/respond.js
@@ -35,19 +35,17 @@ const respond = (request, source) => {
 
 respond.notFound = (request) => {
     const response = new Response({
-            error   : statusText.get(status.NotFound),
-            message : 'Page not found'
-        })
-        .code(status.NotFound);
+        error   : statusText.get(status.NotFound),
+        message : 'Page not found'
+    }).code(status.NotFound);
     return respond(request, response);
 };
 
 respond.badImplementation = (request) => {
     const response = new Response({
-            error   : statusText.get(status.InternalServerError),
-            message : 'An internal error occurred on the server'
-        })
-        .code(status.InternalServerError);
+        error   : statusText.get(status.InternalServerError),
+        message : 'An internal error occurred on the server'
+    }).code(status.InternalServerError);
     return respond(request, response);
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -6,33 +6,33 @@ const getParamName = (segment) => {
     return segment.slice(1, -1);
 };
 
-const sortRoutes = (a, b) => {
-    const aFirst = -1;
-    const bFirst = 1;
+const sortRoutes = (left, right) => {
+    const leftFirst = -1;
+    const rightFirst = 1;
 
-    if (a.segments.filter(isDynamicSegment).length <
-        b.segments.filter(isDynamicSegment).length) {
-        return aFirst;
+    if (left.segments.filter(isDynamicSegment).length <
+        right.segments.filter(isDynamicSegment).length) {
+        return leftFirst;
     }
-    if (a.segments.filter(isDynamicSegment).length >
-        b.segments.filter(isDynamicSegment).length) {
-        return bFirst;
-    }
-
-    if (a.segments.length < b.segments.length) {
-        return aFirst;
-    }
-    if (a.segments.length > b.segments.length) {
-        return bFirst;
+    if (left.segments.filter(isDynamicSegment).length >
+        right.segments.filter(isDynamicSegment).length) {
+        return rightFirst;
     }
 
-    if (a.path.length < b.path.length) {
-        return aFirst;
+    if (left.segments.length < right.segments.length) {
+        return leftFirst;
     }
-    if (a.path.length > b.path.length) {
-        return bFirst;
+    if (left.segments.length > right.segments.length) {
+        return rightFirst;
     }
-}
+
+    if (left.path.length < right.path.length) {
+        return leftFirst;
+    }
+    if (left.path.length > right.path.length) {
+        return rightFirst;
+    }
+};
 
 class Router {
     constructor() {
@@ -40,7 +40,10 @@ class Router {
     }
     add(option, data) {
         const method = option.method.toLowerCase();
-        this.routes[method] = this.routes[method] || { static : new Map(), dynamic : [] };
+        this.routes[method] = this.routes[method] || {
+            static  : new Map(),
+            dynamic : []
+        };
         const table = this.routes[method];
         const segments = option.path.split('/').filter(Boolean);
         const isDynamic = segments.some(isDynamicSegment);
@@ -64,13 +67,13 @@ class Router {
             return {
                 data   : methodTable.static.get(path).data,
                 params : {}
-            }
+            };
         }
         if (wildTable && wildTable.static.has(path)) {
             return {
                 data   : wildTable.static.get(path).data,
                 params : {}
-            }
+            };
         }
         const segments = path.split('/').filter(Boolean);
         const methodDynamic = (methodTable || {}).dynamic || [];

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,7 +6,7 @@ import Router from './router.js';
 
 const getPathname = (path) => {
     return new URL(path, 'http://localhost').pathname;
-}
+};
 
 export default class Server {
     constructor(option) {
@@ -27,7 +27,7 @@ export default class Server {
         const request = new Request({
             raw    : rawRequest,
             route,
-            server : this,
+            server : this
         });
 
         let result;
@@ -50,7 +50,11 @@ export default class Server {
                 throw new TypeError('route.handler must be a function');
             }
             for (const method of [].concat(route.method)) {
-                this.router.add({ ...route, method }, route.handler);
+                const record = {
+                    ...route,
+                    method
+                };
+                this.router.add(record, route.handler);
             }
         }
         return this;

--- a/lib/server.js
+++ b/lib/server.js
@@ -58,6 +58,9 @@ export default class Server {
     async start() {
         const host = this._config.hostname + ':' + this._config.port;
         const server = http.serve(host);
+        setTimeout(() => {
+            server.close();
+        }, 10000);
         for await (const request of server) {
             this.respond(request);
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,65 @@
+import { http } from '../dependencies.js';
+import respond from './respond.js';
+import Request from './request.js';
+import Toolkit from './toolkit.js';
+import Router from './router.js';
+
+const getPathname = (path) => {
+    return new URL(path, 'http://localhost').pathname;
+}
+
+export default class Server {
+    constructor(option) {
+        this._config = {
+            hostname : 'localhost',
+            ...option
+        };
+        this.router = new Router();
+    }
+    async inject(rawRequest) {
+        const route = this.router.route(rawRequest.method, getPathname(rawRequest.url));
+        const handler = route && route.data;
+
+        if (!handler) {
+            return respond.notFound();
+        }
+
+        const request = new Request({
+            raw    : rawRequest,
+            route,
+            server : this,
+        });
+
+        let result;
+        try {
+            result = await handler(request, new Toolkit());
+        }
+        catch (error) {
+            return respond.badImplementation();
+        }
+
+        return respond(request, result);
+    }
+    async respond(request) {
+        const response = await this.inject(request);
+        request.respond(response);
+    }
+    route(routes) {
+        for (const route of [].concat(routes)) {
+            if (typeof route.handler !== 'function') {
+                throw new TypeError('route.handler must be a function');
+            }
+            for (const method of [].concat(route.method)) {
+                this.router.add({ ...route, method }, route.handler);
+            }
+        }
+        return this;
+    }
+    async start() {
+        const host = this._config.hostname + ':' + this._config.port;
+        const server = http.serve(host);
+        for await (const request of server) {
+            this.respond(request);
+        }
+    }
+}

--- a/main.js
+++ b/main.js
@@ -1,66 +1,7 @@
-import { http } from './dependencies.js';
-import respond from './lib/respond.js';
-import Response from './lib/response.js';
-import Toolkit from './lib/toolkit.js';
-import Router from './lib/router.js';
-
-class Pogo {
-    constructor(option) {
-        this._config = {
-            hostname : 'localhost',
-            ...option
-        };
-        this.router = new Router();
-    }
-    async inject(request) {
-        console.log(`Request: ${new Date().toISOString()} ${request.method} ${request.url}`);
-
-        const route = this.router.route(request.method, request.url);
-        const handler = route && route.data;
-
-        if (!handler) {
-            return respond.notFound(request);
-        }
-
-        request.params = route.params;
-        request.response = new Response();
-
-        let result;
-        try {
-            result = await handler(request, new Toolkit());
-        }
-        catch (error) {
-            return respond.badImplementation(request);
-        }
-
-        return respond(request, result);
-    }
-    async respond(request) {
-        const response = await this.inject(request);
-        request.respond(response);
-    }
-    route(routes) {
-        for (const route of [].concat(routes)) {
-            if (typeof route.handler !== 'function') {
-                throw new TypeError('route.handler must be a function');
-            }
-            for (const method of [].concat(route.method)) {
-                this.router.add({ ...route, method }, route.handler);
-            }
-        }
-        return this;
-    }
-    async start() {
-        const host = this._config.hostname + ':' + this._config.port;
-        const server = http.serve(host);
-        for await (const request of server) {
-            this.respond(request);
-        }
-    }
-}
+import Server from './lib/server.js';
 
 export default {
     server(...args) {
-        return new Pogo(...args);
+        return new Server(...args);
     }
 };

--- a/test.js
+++ b/test.js
@@ -1,0 +1,7 @@
+import './test/request.js';
+import './test/router.js';
+import './test/server.js';
+import './test/toolkit.js';
+import { runTests } from './dev-dependencies.js';
+
+runTests();

--- a/test/request.js
+++ b/test/request.js
@@ -184,7 +184,7 @@ test('request.params contains path variables', async () => {
     assertStrictEq(response.status, 200);
     assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
     assertEquals(response.body, encoder.encode(JSON.stringify({
-        type  : 'object',
+        type   : 'object',
         userId : '123',
         value  : {
             userId : '123'

--- a/test/request.js
+++ b/test/request.js
@@ -1,5 +1,5 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.18.0/testing/asserts.ts';
-import { runTests, test } from 'https://deno.land/std@v0.18.0/testing/mod.ts';
+import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
+import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
 import Response from '../lib/response.js';
 import Server from '../lib/server.js';
 import pogo from '../main.js';

--- a/test/request.js
+++ b/test/request.js
@@ -1,0 +1,401 @@
+import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.18.0/testing/asserts.ts';
+import { runTests, test } from 'https://deno.land/std@v0.18.0/testing/mod.ts';
+import Response from '../lib/response.js';
+import Server from '../lib/server.js';
+import pogo from '../main.js';
+
+const encoder = new TextEncoder();
+
+test('request.headers is a Headers instance', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isHeadersInstance : request.headers instanceof Headers,
+                hostHeader        : request.headers.get('host'),
+                type              : typeof request.headers
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isHeadersInstance : true,
+        hostHeader        : 'localhost',
+        type              : 'object'
+    })));
+});
+
+test('request.host is a hostname and port', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isSameAsHeader : request.host === request.headers.get('host'),
+                isSameAsUrl    : request.host === request.url.host,
+                type           : typeof request.host,
+                value          : request.host
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isSameAsHeader : true,
+        isSameAsUrl    : true,
+        type           : 'string',
+        value          : 'localhost'
+    })));
+});
+
+test('request.hostname is a domain or IP address', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isInHostHeader : request.hostname === request.headers.get('host').split(':')[0],
+                isSameAsUrl    : request.hostname === request.url.hostname,
+                type           : typeof request.hostname,
+                value          : request.hostname
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isInHostHeader : true,
+        isSameAsUrl    : true,
+        type           : 'string',
+        value          : 'localhost'
+    })));
+});
+
+test('request.href is a full URL string', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isSameAsUrl : request.href === request.url.href,
+                type        : typeof request.href,
+                value       : request.href
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isSameAsUrl : true,
+        type        : 'string',
+        value       : 'http://localhost/'
+    })));
+});
+
+test('request.method is an HTTP method', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isGet : request.method === 'GET',
+                type  : typeof request.method
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isGet : true,
+        type  : 'string'
+    })));
+});
+
+test('request.origin is a protocol and host', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isSameAsUrl : request.origin === request.url.origin,
+                type        : typeof request.origin,
+                value       : request.origin
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isSameAsUrl : true,
+        type        : 'string',
+        value       : 'http://localhost'
+    })));
+});
+
+test('request.params contains path variables', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/users/{userId}',
+        handler(request) {
+            return {
+                type   : typeof request.params,
+                userId : request.params.userId,
+                value  : request.params
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/users/123'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        type  : 'object',
+        userId : '123',
+        value  : {
+            userId : '123'
+        }
+    })));
+});
+
+test('request.path is a URL path string', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isSameAsUrl : request.path === request.url.pathname,
+                type        : typeof request.path,
+                value       : request.path
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/?query'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isSameAsUrl : true,
+        type        : 'string',
+        value       : '/'
+    })));
+});
+
+test('request.raw is the original request', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isGet : request.raw.method === 'GET',
+                type  : typeof request.raw
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isGet : true,
+        type  : 'object'
+    })));
+});
+
+test('request.response is a Response instance', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isResponseInstance : request.response instanceof Response,
+                type               : typeof request.response
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isResponseInstance : true,
+        type               : 'object'
+    })));
+});
+
+test('request.route is a router record', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                hasHandler : typeof request.route.data === 'function',
+                params     : request.route.params,
+                type       : typeof request.route
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        hasHandler : true,
+        params     : {},
+        type       : 'object'
+    })));
+});
+
+test('request.search is a URL search string', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isSameAsUrl : request.search === request.url.search,
+                type        : typeof request.search,
+                value       : request.search
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/?query'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isSameAsUrl : true,
+        type        : 'string',
+        value       : '?query'
+    })));
+});
+
+test('request.searchParams is a URLSearchParams instance', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                asString         : request.searchParams.toString(),
+                isSameAsUrl      : request.searchParams === request.url.searchParams,
+                isParamsInstance : request.searchParams instanceof URLSearchParams,
+                type             : typeof request.searchParams
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/?query'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        asString         : 'query=',
+        isSameAsUrl      : true,
+        isParamsInstance : true,
+        type             : 'object'
+    })));
+});
+
+test('request.server is a Server instance', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                isServerInstance : request.server instanceof Server,
+                type             : typeof request.server
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        isServerInstance : true,
+        type             : 'object'
+    })));
+});
+
+test('request.url is a URL instance', async () => {
+    const server = pogo.server();
+    server.route({
+        method : 'GET',
+        path   : '/',
+        handler(request) {
+            return {
+                asString      : request.url,
+                href          : request.url.href,
+                isUrlInstance : request.url instanceof URL,
+                type          : typeof request.url
+            };
+        }
+    });
+    const response = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    assertStrictEq(response.status, 200);
+    assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(response.body, encoder.encode(JSON.stringify({
+        asString      : 'http://localhost/',
+        href          : 'http://localhost/',
+        isUrlInstance : true,
+        type          : 'object'
+    })));
+});
+
+runTests();

--- a/test/request.js
+++ b/test/request.js
@@ -1,5 +1,4 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
-import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
+import { assertEquals, assertStrictEq, test } from '../dev-dependencies.js';
 import Response from '../lib/response.js';
 import Server from '../lib/server.js';
 import pogo from '../main.js';
@@ -397,5 +396,3 @@ test('request.url is a URL instance', async () => {
         type          : 'object'
     })));
 });
-
-runTests();

--- a/test/router.js
+++ b/test/router.js
@@ -1,5 +1,5 @@
-import { assertEquals } from 'https://deno.land/std@v0.18.0/testing/asserts.ts';
-import { runTests, test } from 'https://deno.land/std@v0.18.0/testing/mod.ts';
+import { assertEquals } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
+import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
 import Router from '../lib/router.js';
 
 test('add() static routes', () => {

--- a/test/router.js
+++ b/test/router.js
@@ -1,6 +1,6 @@
-import Router from '../lib/router.js';
 import { assertEquals } from 'https://deno.land/std@v0.18.0/testing/asserts.ts';
 import { runTests, test } from 'https://deno.land/std@v0.18.0/testing/mod.ts';
+import Router from '../lib/router.js';
 
 test('add() static routes', () => {
     const router = new Router();

--- a/test/router.js
+++ b/test/router.js
@@ -1,5 +1,4 @@
-import { assertEquals } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
-import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
+import { assertEquals, test } from '../dev-dependencies.js';
 import Router from '../lib/router.js';
 
 test('add() static routes', () => {
@@ -83,5 +82,3 @@ test('route() wildcard method routes', () => {
         }
     });
 });
-
-runTests();

--- a/test/server.js
+++ b/test/server.js
@@ -1,5 +1,5 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.18.0/testing/asserts.ts';
-import { runTests, test } from 'https://deno.land/std@v0.18.0/testing/mod.ts';
+import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
+import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
 import pogo from '../main.js';
 
 const encoder = new TextEncoder();

--- a/test/server.js
+++ b/test/server.js
@@ -20,6 +20,7 @@ test('HTML response for string', async () => {
         url    : '/'
     });
     assertStrictEq(called, true);
+    assertStrictEq(response.status, 200);
     assertStrictEq(response.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(response.body, encoder.encode('hi'));
 });
@@ -40,6 +41,7 @@ test('JSON response for plain object', async () => {
         url    : '/'
     });
     assertStrictEq(called, true);
+    assertStrictEq(response.status, 200);
     assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
     assertEquals(response.body, encoder.encode(JSON.stringify({ foo : 'bar' })));
 });
@@ -68,8 +70,10 @@ test('JSON response for boolean', async () => {
         method : 'GET',
         url    : '/true'
     });
+    assertStrictEq(responseFalse.status, 200);
     assertStrictEq(responseFalse.headers.get('content-type'), 'application/json; charset=utf-8');
     assertEquals(responseFalse.body, encoder.encode(JSON.stringify(false)));
+    assertStrictEq(responseTrue.status, 200);
     assertStrictEq(responseTrue.headers.get('content-type'), 'application/json; charset=utf-8');
     assertEquals(responseTrue.body, encoder.encode(JSON.stringify(true)));
 });
@@ -98,8 +102,10 @@ test('JSON response for number', async () => {
         method : 'GET',
         url    : '/one'
     });
+    assertStrictEq(responseZero.status, 200);
     assertStrictEq(responseZero.headers.get('content-type'), 'application/json; charset=utf-8');
     assertEquals(responseZero.body, encoder.encode(JSON.stringify(0)));
+    assertStrictEq(responseOne.status, 200);
     assertStrictEq(responseOne.headers.get('content-type'), 'application/json; charset=utf-8');
     assertEquals(responseOne.body, encoder.encode(JSON.stringify(1)));
 });
@@ -117,6 +123,7 @@ test('empty response for null', async () => {
         method : 'GET',
         url    : '/'
     });
+    assertStrictEq(response.status, 200);
     assertStrictEq(response.headers.has('content-type'), false);
     assertEquals(response.body, encoder.encode(''));
 });
@@ -155,6 +162,7 @@ test('route with dynamic path', async () => {
         method : 'GET',
         url    : '/users/123'
     });
+    assertStrictEq(response.status, 200);
     assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
     assertEquals(response.body, encoder.encode(JSON.stringify({ userId : '123' })));
 });
@@ -184,8 +192,10 @@ test('server.route() can be chained', async () => {
         method : 'GET',
         url    : '/b'
     });
+    assertStrictEq(responseA.status, 200);
     assertStrictEq(responseA.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(responseA.body, encoder.encode('a'));
+    assertStrictEq(responseB.status, 200);
     assertStrictEq(responseB.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(responseB.body, encoder.encode('b'));
 });
@@ -216,8 +226,10 @@ test('array of routes', async () => {
         method : 'GET',
         url    : '/b'
     });
+    assertStrictEq(responseA.status, 200);
     assertStrictEq(responseA.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(responseA.body, encoder.encode('a'));
+    assertStrictEq(responseB.status, 200);
     assertStrictEq(responseB.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(responseB.body, encoder.encode('b'));
 });
@@ -243,12 +255,18 @@ test('route with array of methods', async () => {
         method : 'PUT',
         url    : '/hello'
     });
+    assertStrictEq(getResponse.status, 200);
     assertStrictEq(getResponse.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(getResponse.body, encoder.encode('Hi, GET'));
+    assertStrictEq(postResponse.status, 200);
     assertStrictEq(postResponse.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(postResponse.body, encoder.encode('Hi, POST'));
     assertStrictEq(putResponse.status, 404);
     assertStrictEq(putResponse.headers.get('content-type'), 'application/json; charset=utf-8');
+    assertEquals(putResponse.body, encoder.encode(JSON.stringify({
+        error   : 'Not Found',
+        message : 'Page not found'
+    })));
 });
 
 test('route with wildcard method', async () => {
@@ -272,10 +290,13 @@ test('route with wildcard method', async () => {
         method : 'PUT',
         url    : '/hello'
     });
+    assertStrictEq(getResponse.status, 200);
     assertStrictEq(getResponse.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(getResponse.body, encoder.encode('Hi, GET'));
+    assertStrictEq(postResponse.status, 200);
     assertStrictEq(postResponse.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(postResponse.body, encoder.encode('Hi, POST'));
+    assertStrictEq(putResponse.status, 200);
     assertStrictEq(putResponse.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(putResponse.body, encoder.encode('Hi, PUT'));
 });

--- a/test/server.js
+++ b/test/server.js
@@ -1,5 +1,4 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
-import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
+import { assertEquals, assertStrictEq, test } from '../dev-dependencies.js';
 import pogo from '../main.js';
 
 const encoder = new TextEncoder();
@@ -300,5 +299,3 @@ test('route with wildcard method', async () => {
     assertStrictEq(putResponse.headers.get('content-type'), 'text/html; charset=utf-8');
     assertEquals(putResponse.body, encoder.encode('Hi, PUT'));
 });
-
-runTests();

--- a/test/toolkit.js
+++ b/test/toolkit.js
@@ -1,5 +1,5 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.18.0/testing/asserts.ts';
-import { runTests, test } from 'https://deno.land/std@v0.18.0/testing/mod.ts';
+import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
+import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
 import pogo from '../main.js';
 
 const encoder = new TextEncoder();

--- a/test/toolkit.js
+++ b/test/toolkit.js
@@ -17,6 +17,7 @@ test('h.response() set JSON body', async () => {
         method : 'GET',
         url    : '/'
     });
+    assertStrictEq(response.status, 200);
     assertStrictEq(response.headers.get('content-type'), 'application/json; charset=utf-8');
     assertEquals(response.body, encoder.encode(JSON.stringify({ hello : 'world' })));
 });
@@ -86,6 +87,7 @@ test('response.header() set custom header', async () => {
         method : 'GET',
         url    : '/'
     });
+    assertStrictEq(response.status, 200);
     assertStrictEq(response.headers.get('content-type'), 'text/html; charset=utf-8');
     assertStrictEq(response.headers.get('x-dog'), 'woof');
     assertEquals(response.body, encoder.encode('hi'));
@@ -104,6 +106,7 @@ test('response.location() set location header', async () => {
         method : 'GET',
         url    : '/'
     });
+    assertStrictEq(response.status, 200);
     assertStrictEq(response.headers.get('content-type'), 'text/html; charset=utf-8');
     assertStrictEq(response.headers.get('location'), '/over-the-rainbow');
     assertEquals(response.body, encoder.encode('hi'));

--- a/test/toolkit.js
+++ b/test/toolkit.js
@@ -1,5 +1,4 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.19.0/testing/asserts.ts';
-import { runTests, test } from 'https://deno.land/std@v0.19.0/testing/mod.ts';
+import { assertEquals, assertStrictEq, test } from '../dev-dependencies.js';
 import pogo from '../main.js';
 
 const encoder = new TextEncoder();
@@ -193,5 +192,3 @@ test('response.type() override default content-type handling', async () => {
     assertStrictEq(response.headers.get('content-type'), 'weird/type');
     assertEquals(response.body, encoder.encode(JSON.stringify({ hello : 'world' })));
 });
-
-runTests();


### PR DESCRIPTION
 - Created a new `Request` class and added many new request properties.
 - Fixed a bug where routes wouldn't be matched correctly if the request URL included a query string.
 - Upgraded to Deno v0.19 and dropped support for older versions.
 - Expanded documentation and tests.