### PR TITLE
Add shortcut for using a custom catch-all handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,20 @@ Example: `3000`
 
 Specifies which port number the server will listen on when [`server.start()`](#serverstart) is called. Use `0` to listen on an available port assigned by the operating system.
 
+##### catchAll
+
+Type: `function`<br>
+Example:
+
+    async (request, h) => {
+        const response = h.response("the void");
+        response.status = 404;
+        return response;
+    }
+
+This is a custom handler (taking precedence over the default one) for requests that do not match any of the defined routes.
+
+
 ### pogo.router(option)
 
 Returns a [`Router`](#router) instance, which can then be used to add routes.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Optional route handler to be used as a fallback for requests that do not match a
 
 ```js
 pogo.server({
-    catchAll : async (request, h) => {
+    catchAll(request, h) {
         return h.response('the void').code(404);
     }
 });

--- a/README.md
+++ b/README.md
@@ -217,9 +217,8 @@ Type: `function`<br>
 Example:
 
     async (request, h) => {
-        const response = h.response("the void");
-        response.status = 404;
-        return response;
+        return h.response("the void")
+            .code(404);
     }
 
 This is a custom handler (taking precedence over the default one) for requests that do not match any of the defined routes.

--- a/dependencies.ts
+++ b/dependencies.ts
@@ -1,8 +1,8 @@
 import React from 'https://dev.jspm.io/react@16.12.0';
 import ReactDOMServer from 'https://dev.jspm.io/react-dom@16.12.0/server';
-import * as cookie from 'https://deno.land/std@v0.53.0/http/cookie.ts';
-import * as http from 'https://deno.land/std@v0.53.0/http/server.ts';
-import { Status as status, STATUS_TEXT as statusText } from 'https://deno.land/std@v0.53.0/http/http_status.ts';
+import * as cookie from 'https://deno.land/std@v0.56.0/http/cookie.ts';
+import * as http from 'https://deno.land/std@v0.56.0/http/server.ts';
+import { Status as status, STATUS_TEXT as statusText } from 'https://deno.land/std@v0.56.0/http/http_status.ts';
 
 export {
     React,

--- a/dev-dependencies.ts
+++ b/dev-dependencies.ts
@@ -2,7 +2,7 @@ import {
     assert,
     assertEquals,
     assertStrictEq
-} from 'https://deno.land/std@v0.53.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.56.0/testing/asserts.ts';
 
 export {
     assert,

--- a/example/simple-server/dev-dependencies.ts
+++ b/example/simple-server/dev-dependencies.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.53.0/testing/asserts.ts';
+import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.56.0/testing/asserts.ts';
 
 export {
     assertEquals,

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -5,13 +5,13 @@ import { RequestParams, MatchedRoute } from './types.ts';
 
 interface RequestOptions {
     raw: http.ServerRequest,
-    route: MatchedRoute,
+    route?: MatchedRoute,
     server: Server
 }
 
 export default class Request {
     raw: http.ServerRequest;
-    route: MatchedRoute;
+    route?: MatchedRoute;
     method: string;
     headers: Headers;
     params: RequestParams
@@ -25,7 +25,7 @@ export default class Request {
         this.route = options.route;
         this.method = this.raw.method;
         this.headers = this.raw.headers || new Headers({ host : 'localhost' });
-        this.params = this.route.params;
+        this.params = this.route ? this.route.params : {};
         this.referrer = this.headers.get('referer') || '';
         this.response = new Response();
         this.server = options.server;

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -5,16 +5,16 @@ import { RequestParams, MatchedRoute } from './types.ts';
 
 interface RequestOptions {
     raw: http.ServerRequest,
-    route?: MatchedRoute,
+    route: MatchedRoute,
     server: Server
 }
 
 export default class Request {
     raw: http.ServerRequest;
-    route?: MatchedRoute;
+    route: MatchedRoute;
     method: string;
     headers: Headers;
-    params: RequestParams
+    params: RequestParams;
     referrer: string;
     response: Response;
     server: Server;
@@ -25,7 +25,7 @@ export default class Request {
         this.route = options.route;
         this.method = this.raw.method;
         this.headers = this.raw.headers || new Headers({ host : 'localhost' });
-        this.params = this.route ? this.route.params : {};
+        this.params = this.route.params;
         this.referrer = this.headers.get('referer') || '';
         this.response = new Response();
         this.server = options.server;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,7 +26,8 @@ export interface MatchedRoute extends NormalizedRoute {
 
 export interface ServerOptions {
     hostname?: string,
-    port: number
+    port: number,
+    catchAll?: RouteHandler,
 }
 
 type JSONStringifyable = boolean | null | number | object | string;

--- a/test/server.jsx
+++ b/test/server.jsx
@@ -434,12 +434,10 @@ test('server.route() handler throws bang.badRequest()', async () => {
     }));
 });
 
-
-test('server.route() catchAll handler', async () => {
+test('server catchAll option', async () => {
     const server = pogo.server({
-        catchAll: async (request, h) => {
-            return h.response(`My custom response, ${ request.method }`)
-                .code(404);
+        catchAll(request, h) {
+            return h.response('Custom fallback, ' + request.method).code(418);
         }
     });
     server.route({
@@ -449,29 +447,32 @@ test('server.route() catchAll handler', async () => {
             return 'Hi, ' + request.method;
         }
     });
-    const getResponseExists = await server.inject({
+    const getHelloResponse = await server.inject({
         method : 'GET',
         url    : '/hello'
     });
-    const getResponseNotExists = await server.inject({
+    const getRootResponse = await server.inject({
+        method : 'GET',
+        url    : '/'
+    });
+    const getVoidResponse = await server.inject({
         method : 'GET',
         url    : '/void'
     });
-    const postResponseNotExists = await server.inject({
+    const postVoidResponse = await server.inject({
         method : 'POST',
         url    : '/void'
     });
-
-
-    assertStrictEq(getResponseExists.status, 200);
-    assertStrictEq(getResponseExists.headers.get('content-type'), 'text/html; charset=utf-8');
-    assertStrictEq(getResponseExists.body, 'Hi, GET');
-
-    assertStrictEq(getResponseNotExists.status, 404);
-    assertStrictEq(getResponseNotExists.body, 'My custom response, GET');
-
-    assertStrictEq(postResponseNotExists.status, 404);
-    assertStrictEq(postResponseNotExists.body, 'My custom response, POST');
-
-
+    assertStrictEq(getHelloResponse.status, 200);
+    assertStrictEq(getHelloResponse.headers.get('content-type'), 'text/html; charset=utf-8');
+    assertStrictEq(getHelloResponse.body, 'Hi, GET');
+    assertStrictEq(getRootResponse.status, 418);
+    assertStrictEq(getRootResponse.headers.get('content-type'), 'text/html; charset=utf-8');
+    assertStrictEq(getRootResponse.body, 'Custom fallback, GET');
+    assertStrictEq(getVoidResponse.status, 418);
+    assertStrictEq(getVoidResponse.headers.get('content-type'), 'text/html; charset=utf-8');
+    assertStrictEq(getVoidResponse.body, 'Custom fallback, GET');
+    assertStrictEq(postVoidResponse.status, 418);
+    assertStrictEq(postVoidResponse.headers.get('content-type'), 'text/html; charset=utf-8');
+    assertStrictEq(postVoidResponse.body, 'Custom fallback, POST');
 });

--- a/test/server.jsx
+++ b/test/server.jsx
@@ -438,9 +438,8 @@ test('server.route() handler throws bang.badRequest()', async () => {
 test('server.route() catchAll handler', async () => {
     const server = pogo.server({
         catchAll: async (request, h) => {
-            const response = h.response(`My custom response, ${ request.method }`);
-            response.status = 404;
-            return response;
+            return h.response(`My custom response, ${ request.method }`)
+                .code(404);
         }
     });
     server.route({

--- a/test/server.jsx
+++ b/test/server.jsx
@@ -433,3 +433,46 @@ test('server.route() handler throws bang.badRequest()', async () => {
         status  : 400
     }));
 });
+
+
+test('server.route() catchAll handler', async () => {
+    const server = pogo.server({
+        catchAll: async (request, h) => {
+            const response = h.response(`My custom response, ${ request.method }`);
+            response.status = 404;
+            return response;
+        }
+    });
+    server.route({
+        method : 'GET',
+        path   : '/hello',
+        handler(request) {
+            return 'Hi, ' + request.method;
+        }
+    });
+    const getResponseExists = await server.inject({
+        method : 'GET',
+        url    : '/hello'
+    });
+    const getResponseNotExists = await server.inject({
+        method : 'GET',
+        url    : '/void'
+    });
+    const postResponseNotExists = await server.inject({
+        method : 'POST',
+        url    : '/void'
+    });
+
+
+    assertStrictEq(getResponseExists.status, 200);
+    assertStrictEq(getResponseExists.headers.get('content-type'), 'text/html; charset=utf-8');
+    assertStrictEq(getResponseExists.body, 'Hi, GET');
+
+    assertStrictEq(getResponseNotExists.status, 404);
+    assertStrictEq(getResponseNotExists.body, 'My custom response, GET');
+
+    assertStrictEq(postResponseNotExists.status, 404);
+    assertStrictEq(postResponseNotExists.body, 'My custom response, POST');
+
+
+});


### PR DESCRIPTION
Implemented here as an option to the server instantiation.

```
    const server = pogo.server({
        catchAll: async (request, h) => {
            return h.response(`My custom response, ${ request.method }`)
                .code(404);
        }
    });
```


I started to use pogo to create a development server and quickly realized i wanted to create a catch-all handler for missing routes (akin to the wildcard method matching feature). Happy if you will consider this contribution in some way!

Best regards
/p