### PR TITLE
Make request.body a getter

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -14,8 +14,8 @@ export default class Request {
         this.state = cookie.getCookies(this);
         this.url = new URL(this.raw.url, 'http://' + this.headers.get('host'));
     }
-    body(...args) {
-        return this.raw.body(...args);
+    get body() {
+        return this.raw.body;
     }
     get host() {
         return this.url.host;


### PR DESCRIPTION
in the raw request the body function is a getter, so we need to wrap it as a getter here too, otherwise we will not be able to read from the result.

now the following code will work properly. i think in the future it will be convenient to have a function just returning the body as string.

    async function getBody(request:pogo.Request) {
    	console.log("MAIN.GETBODY");
    	const br = request.body;
    	const bufferContent = await Deno.readAll(br);
    	const bodyText = new TextDecoder().decode(bufferContent);
    	return JSON.parse(bodyText);
    }