### PR TITLE
Update curl command to download examples

### DIFF
--- a/example/hello-world/README.md
+++ b/example/hello-world/README.md
@@ -21,7 +21,7 @@ deno -A https://deno.land/x/pogo/example/hello-world/run.ts
 Alternatively, if you want to play around with the example, run it from a local file:
 
 ```sh
-curl -fsSL https://github.com/sholladay/pogo/archive/master.tar.gz | tar -x --strip-components=1 'pogo-master/example'
+curl -fsSL https://github.com/sholladay/pogo/archive/master.tar.gz | tar -xz --strip-components=1 'pogo-master/example'
 deno -A example/hello-world/run.ts
 ```
 

--- a/example/simple-server/README.md
+++ b/example/simple-server/README.md
@@ -22,6 +22,6 @@ deno -A https://deno.land/x/pogo/example/simple-server/run.ts
 Alternatively, if you want to play around with the example, run it from a local file:
 
 ```sh
-curl -fsSL https://github.com/sholladay/pogo/archive/master.tar.gz | tar -x --strip-components=1 'pogo-master/example'
+curl -fsSL https://github.com/sholladay/pogo/archive/master.tar.gz | tar -xz --strip-components=1 'pogo-master/example'
 deno -A example/simple-server/run.ts
 ```


### PR DESCRIPTION
Running the `tar` command without the `-z` option will fail to download the project files and prompt you the following error:
```
curl -fsSL https://github.com/sholladay/pogo/archive/master.tar.gz | tar -x --strip-components=1 'pogo-master/example'
tar: Archive is compressed. Use -z option
tar: Error is not recoverable: exiting now
curl: (23) Failed writing body (0 != 1363)
```

This pull requests add the `z` option to the `tar` command and lets it download the files properly.