### PR TITLE
Update to Deno 0.42.0 and std 0.50.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 install:
-  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.41.0
+  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.42.0
   - export PATH="$HOME/.deno/bin:$PATH"
 
 script:

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Type: [`Reader`](https://deno.land/typedoc/interfaces/deno.reader.html)
 
 The HTTP [body](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#Body) value.
 
-You can read raw bytes from the body in chunks with `request.body.read()`, which takes a [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) as an argument to copy the bytes into and returns a `Promise` for the number of bytes read when the body is finished being read.
+You can read raw bytes from the body in chunks with `request.body.read()`, which takes a [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) as an argument to copy the bytes into and returns a `Promise` for either the number of bytes read or `null` when the body is finished being read.
 
 ```js
 const decoder = new TextDecoder();

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Pogo is an easy-to-use, safe, and expressive framework for writing web servers and applications. It is inspired by [hapi](https://github.com/hapijs/hapi).
 
-*Supports Deno v0.41.0 and higher.*
+*Supports Deno v0.42.0 and higher.*
 
 ## Contents
 
@@ -350,7 +350,7 @@ Type: [`Reader`](https://deno.land/typedoc/interfaces/deno.reader.html)
 
 The HTTP [body](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#Body) value.
 
-You can read raw bytes from the body in chunks with `request.body.read()`, which takes a [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) as an argument to copy the bytes into and returns a `Promise` for either the number of bytes read or `Deno.EOF` when the body is finished being read.
+You can read raw bytes from the body in chunks with `request.body.read()`, which takes a [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) as an argument to copy the bytes into and returns a `Promise` for the number of bytes read when the body is finished being read.
 
 ```js
 const decoder = new TextDecoder();

--- a/dependencies.ts
+++ b/dependencies.ts
@@ -1,8 +1,8 @@
 import React from 'https://dev.jspm.io/react@16.12.0';
 import ReactDOMServer from 'https://dev.jspm.io/react-dom@16.12.0/server';
-import * as cookie from 'https://deno.land/std@v0.41.0/http/cookie.ts';
-import * as http from 'https://deno.land/std@v0.41.0/http/server.ts';
-import { Status as status, STATUS_TEXT as statusText } from 'https://deno.land/std@v0.41.0/http/http_status.ts';
+import * as cookie from 'https://deno.land/std@v0.50.0/http/cookie.ts';
+import * as http from 'https://deno.land/std@v0.50.0/http/server.ts';
+import { Status as status, STATUS_TEXT as statusText } from 'https://deno.land/std@v0.50.0/http/http_status.ts';
 
 export {
     React,

--- a/dev-dependencies.ts
+++ b/dev-dependencies.ts
@@ -2,7 +2,7 @@ import {
     assert,
     assertEquals,
     assertStrictEq
-} from 'https://deno.land/std@v0.41.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.50.0/testing/asserts.ts';
 
 export {
     assert,

--- a/example/simple-server/dev-dependencies.ts
+++ b/example/simple-server/dev-dependencies.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.41.0/testing/asserts.ts';
+import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.50.0/testing/asserts.ts';
 
 export {
     assertEquals,


### PR DESCRIPTION
This PR addresses the errors experienced on startup relating to using `std` version 0.41.0 with the latest version of `deno`, v1.0.0-rc1. Upgrading `std` to version 0.50.0 resolved this issue. These changes were smoke tested locally with a "hello, world" example. Closes #26 