### PR TITLE
Router v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 install:
-  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v0.41.0
+  - curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.0.2
   - export PATH="$HOME/.deno/bin:$PATH"
 
 script:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Pogo is an easy-to-use, safe, and expressive framework for writing web servers and applications. It is inspired by [hapi](https://github.com/hapijs/hapi).
 
-*Supports Deno v0.41.0 and higher.*
+*Supports Deno v1.0.0 and higher.*
 
 ## Contents
 
@@ -340,7 +340,7 @@ console.log('Stopped listening for requests');
 
 ### Request
 
-The `request` object passed to route handlers represents an HTTP [request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview#Requests) that was sent to the server. It is similar to an instance of Deno's [`ServerRequest`](https://github.com/denoland/deno_std/blob/a4a8bb2948e5984656724c51a803293ce82c035f/http/server.ts#L100-L202) class, with some additions.
+The `request` object passed to route handlers represents an HTTP [request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview#Requests) that was sent to the server. It is similar to an instance of Deno's [`ServerRequest`](https://doc.deno.land/https/deno.land/std/http/mod.ts#ServerRequest) class, with some additions.
 
 It provides properties and methods for inspecting the content of the request.
 
@@ -428,7 +428,7 @@ The path part of the request URL, excluding the query. Shortcut for `request.url
 
 #### request.raw
 
-Type: [`ServerRequest`](https://github.com/denoland/deno_std/blob/5d0dd5878e82ab7577356096469a7e280efe8442/http/server.ts#L100-L202)
+Type: [`ServerRequest`](https://doc.deno.land/https/deno.land/std/http/mod.ts#ServerRequest)
 
 The original request object from Deno's `http` module, upon which many of the other request properties are based.
 
@@ -572,7 +572,7 @@ Returns the response so other methods can be chained.
 
 #### response.state(name, value)
 
-Sets the [`Set-Cookie`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) header to create a cookie with the given `name` and `value`. Cookie options can be specified by using an object for `value`. See Deno's [cookie](https://github.com/denoland/deno/blob/a61966a243cd5d09031fabd9a572a75aab8d2da8/std/http/cookie.ts#L12-L23) interface for the available options.
+Sets the [`Set-Cookie`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) header to create a cookie with the given `name` and `value`. Cookie options can be specified by using an object for `value`. See Deno's [cookie](https://doc.deno.land/https/deno.land/std/http/cookie.ts#Cookie) interface for the available options.
 
 Returns the response so other methods can be chained.
 

--- a/dependencies.ts
+++ b/dependencies.ts
@@ -1,8 +1,8 @@
 import React from 'https://dev.jspm.io/react@16.12.0';
 import ReactDOMServer from 'https://dev.jspm.io/react-dom@16.12.0/server';
-import * as cookie from 'https://deno.land/std@v0.41.0/http/cookie.ts';
-import * as http from 'https://deno.land/std@v0.41.0/http/server.ts';
-import { Status as status, STATUS_TEXT as statusText } from 'https://deno.land/std@v0.41.0/http/http_status.ts';
+import * as cookie from 'https://deno.land/std@v0.53.0/http/cookie.ts';
+import * as http from 'https://deno.land/std@v0.53.0/http/server.ts';
+import { Status as status, STATUS_TEXT as statusText } from 'https://deno.land/std@v0.53.0/http/http_status.ts';
 
 export {
     React,

--- a/dev-dependencies.ts
+++ b/dev-dependencies.ts
@@ -2,7 +2,7 @@ import {
     assert,
     assertEquals,
     assertStrictEq
-} from 'https://deno.land/std@v0.41.0/testing/asserts.ts';
+} from 'https://deno.land/std@v0.53.0/testing/asserts.ts';
 
 export {
     assert,

--- a/example/simple-server/dev-dependencies.ts
+++ b/example/simple-server/dev-dependencies.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.41.0/testing/asserts.ts';
+import { assertEquals, assertStrictEq } from 'https://deno.land/std@v0.53.0/testing/asserts.ts';
 
 export {
     assertEquals,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,7 +14,7 @@ export type RequestParams = { [param: string]: string };
 export interface RouteOptions extends Omit<Partial<Route>, 'method' | 'path'> {
     method?: Route['method'] | Iterable<Route['method']>,
     path?: Route['path'] | Iterable<Route['path']>
-};
+}
 
 export interface NormalizedRoute extends Route {
     segments: Array<string>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,7 +11,10 @@ export interface Route {
 
 export type RequestParams = { [param: string]: string };
 
-export type RouteOptions = Partial<Route>;
+export interface RouteOptions extends Omit<Partial<Route>, 'method' | 'path'> {
+    method?: Route['method'] | Iterable<Route['method']>,
+    path?: Route['path'] | Iterable<Route['path']>
+};
 
 export interface NormalizedRoute extends Route {
     segments: Array<string>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,7 +5,8 @@ import Toolkit from './toolkit.ts';
 export interface Route {
     method: string,
     path: string,
-    handler: RouteHandler
+    handler: RouteHandler,
+    vhost?: string
 }
 
 export type RequestParams = { [param: string]: string };

--- a/test/request.js
+++ b/test/request.js
@@ -335,7 +335,7 @@ test('request.route is a router record', async () => {
             api : 'status'
         },
         path     : '/{api}',
-        segments : ['{api}'],
+        segments : ['', '{api}'],
         type     : 'object'
     }));
 });

--- a/test/router.js
+++ b/test/router.js
@@ -10,18 +10,22 @@ test('new Router() static route', () => {
         xyz    : 123
     });
 
+    const record = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -32,16 +36,22 @@ test('new Router() dynamic route', () => {
         xyz    : 123
     });
 
+    const record = {
+        method   : 'GET',
+        path     : '/{username}',
+        segments : ['', '{username}'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [{
-                method   : 'GET',
-                path     : '/{username}',
-                segments : ['{username}'],
-                xyz      : 123
-            }],
-            static : new Map()
-        }
+        conflictIds : new Map([
+            ['GET /?', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -55,18 +65,22 @@ test('new Router() router instance', () => {
     const extendedRouter = new Router();
     extendedRouter.add(baseRouter);
 
+    const record = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(extendedRouter.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
     assertEquals(extendedRouter.routes, baseRouter.routes);
 });
@@ -78,29 +92,29 @@ test('new Router() array of methods', () => {
         xyz    : 123
     });
 
+    const getHello = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+    const postHello = {
+        method   : 'POST',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        },
-        post : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'POST',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', getHello],
+            ['POST /hello', postHello]
+        ]),
+        list: [getHello, postHello],
+        pathfinders : new Map([
+            ['/.', [getHello, postHello]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -118,24 +132,29 @@ test('new Router() array of routes', () => {
         }]
     ]);
 
+    const bye = {
+        method   : 'GET',
+        path     : '/bye',
+        segments : ['', 'bye'],
+        xyz      : 123
+    };
+    const hello = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/bye', {
-                    method   : 'GET',
-                    path     : '/bye',
-                    segments : ['bye'],
-                    xyz      : 123
-                }],
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /bye', bye],
+            ['GET /hello', hello]
+        ]),
+        list: [bye, hello],
+        pathfinders : new Map([
+            ['/.', [bye, hello]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -149,32 +168,33 @@ test('new Router() mixed route array with default method', () => {
         })
     ], { method : 'GET' });
 
+    const one = {
+        path     : '/one',
+        method   : 'GET',
+        segments : ['', 'one']
+    };
+    const two = {
+        path     : '/two',
+        method   : 'GET',
+        segments : ['', 'two']
+    };
+    const three = {
+        method   : 'POST',
+        path     : '/three',
+        segments : ['', 'three']
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/one', {
-                    method   : 'GET',
-                    path     : '/one',
-                    segments : ['one']
-                }],
-                ['/two', {
-                    method   : 'GET',
-                    path     : '/two',
-                    segments : ['two']
-                }]
-            ])
-        },
-        post : {
-            dynamic : [],
-            static  : new Map([
-                ['/three', {
-                    method   : 'POST',
-                    path     : '/three',
-                    segments : ['three']
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /one', one],
+            ['GET /two', two],
+            ['POST /three', three]
+        ]),
+        list: [one, three, two],
+        pathfinders : new Map([
+            ['/.', [one, three, two]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -186,18 +206,22 @@ test('router.add() static route', () => {
         xyz    : 123
     });
 
+    const record = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -209,16 +233,22 @@ test('router.add() dynamic route', () => {
         xyz    : 123
     });
 
+    const record = {
+        method   : 'GET',
+        path     : '/{username}',
+        segments : ['', '{username}'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [{
-                method   : 'GET',
-                path     : '/{username}',
-                segments : ['{username}'],
-                xyz      : 123
-            }],
-            static : new Map()
-        }
+        conflictIds : new Map([
+            ['GET /?', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -233,18 +263,22 @@ test('router.add() router instance', () => {
     const extendedRouter = new Router();
     extendedRouter.add(baseRouter);
 
+    const record = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(extendedRouter.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
     assertEquals(extendedRouter.routes, baseRouter.routes);
 });
@@ -257,29 +291,29 @@ test('router.add() array of methods', () => {
         xyz    : 123
     });
 
+    const getHello = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+    const postHello = {
+        method   : 'POST',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        },
-        post : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'POST',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', getHello],
+            ['POST /hello', postHello]
+        ]),
+        list: [getHello, postHello],
+        pathfinders : new Map([
+            ['/.', [getHello, postHello]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -298,24 +332,29 @@ test('router.add() array of routes', () => {
         }]
     ]);
 
+    const bye = {
+        method   : 'GET',
+        path     : '/bye',
+        segments : ['', 'bye'],
+        xyz      : 123
+    };
+    const hello = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/bye', {
-                    method   : 'GET',
-                    path     : '/bye',
-                    segments : ['bye'],
-                    xyz      : 123
-                }],
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /bye', bye],
+            ['GET /hello', hello]
+        ]),
+        list: [bye, hello],
+        pathfinders : new Map([
+            ['/.', [bye, hello]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -330,32 +369,33 @@ test('router.add() mixed route array with default method', () => {
         })
     ], { method : 'GET' });
 
+    const one = {
+        path     : '/one',
+        method   : 'GET',
+        segments : ['', 'one']
+    };
+    const two = {
+        path     : '/two',
+        method   : 'GET',
+        segments : ['', 'two']
+    };
+    const three = {
+        method   : 'POST',
+        path     : '/three',
+        segments : ['', 'three']
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/one', {
-                    method   : 'GET',
-                    path     : '/one',
-                    segments : ['one']
-                }],
-                ['/two', {
-                    method   : 'GET',
-                    path     : '/two',
-                    segments : ['two']
-                }]
-            ])
-        },
-        post : {
-            dynamic : [],
-            static  : new Map([
-                ['/three', {
-                    method   : 'POST',
-                    path     : '/three',
-                    segments : ['three']
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /one', one],
+            ['GET /two', two],
+            ['POST /three', three]
+        ]),
+        list: [one, three, two],
+        pathfinders : new Map([
+            ['/.', [one, three, two]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -366,18 +406,22 @@ test('router.get(options)', () => {
         xyz  : 123
     });
 
+    const record = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -385,18 +429,22 @@ test('router.get(path, options)', () => {
     const router = new Router();
     router.get('/hello', { xyz : 123 });
 
+    const record = {
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -405,18 +453,22 @@ test('router.get(path, handler)', () => {
     const handler = () => {};
     router.get('/hello', handler);
 
+    const record = {
+        handler,
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello']
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    handler,
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello']
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -428,19 +480,23 @@ test('router.get(options, handler)', () => {
         xyz  : 123
     }, handler);
 
+    const record = {
+        handler,
+        method   : 'GET',
+        path     : '/hello',
+        segments : ['', 'hello'],
+        xyz      : 123
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    handler,
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -449,19 +505,23 @@ test('router.get(path, options, handler)', () => {
     const handler = () => {};
     router.get('/hello', { xyz : 123 }, handler);
 
+    const record = {
+        path     : '/hello',
+        xyz      : 123,
+        method   : 'GET',
+        handler,
+        segments : ['', 'hello']
+    };
+
     assertEquals(router.routes, {
-        get : {
-            dynamic : [],
-            static  : new Map([
-                ['/hello', {
-                    handler,
-                    method   : 'GET',
-                    path     : '/hello',
-                    segments : ['hello'],
-                    xyz      : 123
-                }]
-            ])
-        }
+        conflictIds : new Map([
+            ['GET /hello', record]
+        ]),
+        list: [record],
+        pathfinders : new Map([
+            ['/.', [record]]
+        ]),
+        wildcards : []
     });
 });
 
@@ -476,7 +536,7 @@ test('router.lookup() static routes', () => {
         method   : 'GET',
         params   : {},
         path     : '/hello',
-        segments : ['hello'],
+        segments : ['', 'hello'],
         xyz      : 123
     });
     assertEquals(router.lookup('POST', '/hello'), undefined);
@@ -497,7 +557,7 @@ test('router.lookup() dynamic routes', () => {
             userId : 'abc'
         },
         path     : '/{api}/{userId}',
-        segments : ['{api}', '{userId}'],
+        segments : ['', '{api}', '{userId}'],
         xyz      : 123
     });
     assertEquals(router.lookup('POST', '/users/abc'), undefined);
@@ -517,7 +577,7 @@ test('router.lookup() wildcard method routes', () => {
             userId : 'foo'
         },
         path     : '/users/{userId}',
-        segments : ['users', '{userId}'],
+        segments : ['', 'users', '{userId}'],
         xyz      : 123
     });
     assertEquals(router.lookup('POST', '/users/foo'), {
@@ -526,7 +586,7 @@ test('router.lookup() wildcard method routes', () => {
             userId : 'foo'
         },
         path     : '/users/{userId}',
-        segments : ['users', '{userId}'],
+        segments : ['', 'users', '{userId}'],
         xyz      : 123
     });
     assertEquals(router.lookup('GET', '/users/bar'), {
@@ -535,14 +595,14 @@ test('router.lookup() wildcard method routes', () => {
             userId : 'bar'
         },
         path     : '/users/{userId}',
-        segments : ['users', '{userId}'],
+        segments : ['', 'users', '{userId}'],
         xyz      : 123
     });
     assertEquals(router.lookup('GET', '/users'), undefined);
     assertEquals(router.lookup('GET', '/users/'), undefined);
 });
 
-test('router.lookup() not found', () => {
+test('router.lookup() not found without catch-all', () => {
     const router = new Router({
         method : '*',
         path   : '/one',
@@ -550,4 +610,30 @@ test('router.lookup() not found', () => {
     });
     assertEquals(router.lookup('GET', '/'), undefined);
     assertEquals(router.lookup('GET', '/two'), undefined);
+});
+
+test('router.lookup() catch-all', () => {
+    const router = new Router({
+        method : '*',
+        path   : '/{any*}',
+        xyz    : 123
+    });
+    assertEquals(router.lookup('GET', '/'), {
+        method : '*',
+        params : {
+            any : ''
+        },
+        path     : '/{any*}',
+        segments : ['', '{any*}'],
+        xyz      : 123
+    });
+    assertEquals(router.lookup('GET', '/foo'), {
+        method : '*',
+        params : {
+            any : 'foo'
+        },
+        path     : '/{any*}',
+        segments : ['', '{any*}'],
+        xyz      : 123
+    });
 });


### PR DESCRIPTION
This PR makes big changes to how the routing table of the `Router` class works and adds support for catch-all routes, improved path parameter handling, and makes the routing table easier to use.

Additionally, Deno 1.0 is officially supported now (it was already working on `master`) and the `std` dependencies have been updated.