### PR TITLE
Update dependencies.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Pogo automatically renders React elements using [`ReactDOMServer.renderToStaticM
 Save the code below to a file named `server.jsx` and run it with a command like `deno --allow-net server.jsx`. The `.jsx` extension is important, as it tells Deno to compile the JSX syntax. You can also use TypeScript by using `.tsx` instead of `.jsx`. The type definitions should load automatically from the Pika CDN, but if you run into problems when using `.tsx`, try loading them manually (see [deno_types](https://github.com/Soremwar/deno_types)).
 
 ```tsx
-import React from 'https://cdn.pika.dev/react';
+import React from 'https://dev.jspm.io/react';
 import pogo from 'https://deno.land/x/pogo/main.ts';
 
 const server = pogo.server({ port : 3000 });

--- a/dependencies.ts
+++ b/dependencies.ts
@@ -1,4 +1,5 @@
-import React from 'https://cdn.skypack.dev/react@16.13.1';
+// @deno-types="https://github.com/soremwar/deno_types/raw/4a5066025e84d2c5353d0f40a8869c65d7c82734/react/v16.13.1/react.d.ts"
+import React from 'https://jspm.dev/react@16.13.1';
 // @deno-types="https://github.com/soremwar/deno_types/raw/4a5066025e84d2c5353d0f40a8869c65d7c82734/react-dom/v16.13.1/server.d.ts"
 import ReactDOMServer from 'https://jspm.dev/react-dom@16.13.1/server';
 import * as cookie from 'https://deno.land/std@v0.64.0/http/cookie.ts';

--- a/dependencies.ts
+++ b/dependencies.ts
@@ -1,4 +1,4 @@
-import React from 'https://cdn.pika.dev/react@16.13.1';
+import React from 'https://cdn.skypack.dev/react@16.13.1';
 // @deno-types="https://github.com/soremwar/deno_types/raw/4a5066025e84d2c5353d0f40a8869c65d7c82734/react-dom/v16.13.1/server.d.ts"
 import ReactDOMServer from 'https://jspm.dev/react-dom@16.13.1/server';
 import * as cookie from 'https://deno.land/std@v0.64.0/http/cookie.ts';

--- a/example/react-on-server/dependencies.ts
+++ b/example/react-on-server/dependencies.ts
@@ -1,5 +1,6 @@
 import pogo from 'https://deno.land/x/pogo/main.ts';
-import React from 'https://cdn.pika.dev/react@16.13.1';
+// @deno-types="https://github.com/soremwar/deno_types/raw/4a5066025e84d2c5353d0f40a8869c65d7c82734/react/v16.13.1/react.d.ts"
+import React from 'https://jspm.dev/react@16.13.1';
 
 export {
     pogo,


### PR DESCRIPTION
Closes #49 

You can validate that the pika URL was causing the issue by running `deno cache -r https://cdn.pika.dev/react@16.13.1`.

This produced the thread panic error.

```
thread 'main' panicked at 'url redirection should provide 'location' header', cli/http_util.rs:141:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Switching to the skypack.dev dependency fixes this issue. I did not modify any other pika.dev routes, since it does not seem to be consistent for all.