### PR TITLE
Fix missing type on exports

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,5 +38,5 @@ export type ResponseBody = Deno.Reader | Uint8Array | JSONStringifyable;
 export type RouteHandlerResult = Response | ResponseBody | Error | Promise<Response | ResponseBody | Error>;
 export type RouteHandler = (request: Request, h: Toolkit) => RouteHandlerResult;
 
-export { FileHandlerOptions } from './helpers/file.ts';
-export { DirectoryHandlerOptions } from './helpers/directory.tsx';
+export type { FileHandlerOptions } from './helpers/file.ts';
+export type { DirectoryHandlerOptions } from './helpers/directory.tsx';

--- a/lib/util/read-dir-stats.ts
+++ b/lib/util/read-dir-stats.ts
@@ -20,6 +20,6 @@ const readDirStats = async (dir: string): Promise<Array<NamedStat>> => {
 };
 
 export default readDirStats;
-export {
+export type {
     NamedStat
 };


### PR DESCRIPTION
If launched with `--unstable` option, for example with `--watch`, we got a typescript error when exporting types.
This PR fix this

![Capture d’écran du 2020-10-11 17-29-11](https://user-images.githubusercontent.com/654335/95682788-9039f380-0be7-11eb-8f89-999fefd5b5ea.png)
