### PR TITLE
Mention how to use a public hostname in usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ Pogo is an easy-to-use, safe, and expressive framework for writing web servers a
 
 ## Usage
 
-Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page.
+Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. To listen over network, add `hostname : '0.0.0.0` in the server options.
 
 ```ts
 import pogo from 'https://deno.land/x/pogo/main.ts';
 
 const server = pogo.server({ port : 3000 });
-//Add "hostname : '0.0.0.0'" to access over network
 
 server.router.get('/', () => {
     return 'Hello, world!';

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pogo is an easy-to-use, safe, and expressive framework for writing web servers a
 
 ## Usage
 
-Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. To expose the server publicly so you can access it from other machines, add `hostname : '0.0.0.0'` to the server options.
+Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. To make the server publicly accessible from other machines, add `hostname : '0.0.0.0'` to the options.
 
 ```ts
 import pogo from 'https://deno.land/x/pogo/main.ts';

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pogo is an easy-to-use, safe, and expressive framework for writing web servers a
 
 ## Usage
 
-Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. To listen over network, add `hostname : '0.0.0.0` in the server options.
+Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. To listen over network, add `hostname : '0.0.0.0'` in the server options.
 
 ```ts
 import pogo from 'https://deno.land/x/pogo/main.ts';

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pogo is an easy-to-use, safe, and expressive framework for writing web servers a
 
 ## Usage
 
-Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. If you want to expose the server publicly so you can access it from other machines, add `hostname : '0.0.0.0'` to the server options.
+Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. To expose the server publicly so you can access it from other machines, add `hostname : '0.0.0.0'` to the server options.
 
 ```ts
 import pogo from 'https://deno.land/x/pogo/main.ts';

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Save the code below to a file named `server.js` and run it with a command like `
 import pogo from 'https://deno.land/x/pogo/main.ts';
 
 const server = pogo.server({ port : 3000 });
-//Add { hostname : '0.0.0.0' } to access over network
+//Add "hostname : '0.0.0.0'" to access over network
 
 server.router.get('/', () => {
     return 'Hello, world!';

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pogo is an easy-to-use, safe, and expressive framework for writing web servers a
 
 ## Usage
 
-Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. To listen over network, add `hostname : '0.0.0.0'` in the server options.
+Save the code below to a file named `server.js` and run it with a command like `deno run --allow-net server.js`. Then visit http://localhost:3000 in your browser and you should see "Hello, world!" on the page. If you want to expose the server publicly so you can access it from other machines, add `hostname : '0.0.0.0'` to the server options.
 
 ```ts
 import pogo from 'https://deno.land/x/pogo/main.ts';


### PR DESCRIPTION
Pogo is the only Deno networking framework without default networking. Worth a mention.